### PR TITLE
added reference path for puzzle

### DIFF
--- a/Backend/src/router/static.js
+++ b/Backend/src/router/static.js
@@ -6,6 +6,7 @@ export const lottery = '/statics/Lottery'
 export const wallet = '/statics/WebWallet'
 export const index = '/statics/Index'
 export const faucet = '/statics/Faucet'
+export const puzzle = '/statics/Puzzle'
 
 const routerTable = [
   {


### PR DESCRIPTION
This fixed the puzzle reference not found error while performing yarn start at the project root.